### PR TITLE
updated lax parser to allow 1 or 2 digit millisecond components

### DIFF
--- a/iso8601.js
+++ b/iso8601.js
@@ -10,7 +10,7 @@
         var timestamp, struct, minutesOffset = 0;
 
         //              1 YYYY                 2 MM        3 DD              4 HH     5 mm        6 ss            7 msec         8 Z 9 ±    10 tzHH    11 tzmm
-        if ((struct = /^(\d{4}|[+\-]\d{6})(?:-?(\d{2})(?:-?(\d{2}))?)?(?:[ T]?(\d{2}):?(\d{2})(?::?(\d{2})(?:[,\.](\d{3,}))?)?(?:(Z)|([+\-])(\d{2})(?::?(\d{2}))?)?)?$/.exec(date))) {
+        if ((struct = /^(\d{4}|[+\-]\d{6})(?:-?(\d{2})(?:-?(\d{2}))?)?(?:[ T]?(\d{2}):?(\d{2})(?::?(\d{2})(?:[,\.](\d{1,}))?)?(?:(Z)|([+\-])(\d{2})(?::?(\d{2}))?)?)?$/.exec(date))) {
             // avoid NaN timestamps caused by “undefined” values being passed to Date.UTC
             for (var i = 0, k; (k = numericKeys[i]); ++i) {
                 struct[k] = +struct[k] || 0;
@@ -21,7 +21,7 @@
             struct[3] = +struct[3] || 1;
 
             // allow arbitrary sub-second precision beyond milliseconds
-            struct[7] = struct[7] ? +struct[7].substr(0, 3) : 0;
+            struct[7] = struct[7] ? + (struct[7] + "00").substr(0, 3) : 0;
 
             // timestamps without timezone identifiers should be considered local time
             if (struct[8] === undefined && struct[9] === undefined) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -33,7 +33,7 @@ test('date-part', 16, function () {
     // TODO: Test for invalid YYYYMM and invalid YYYYY?
 });
 
-test('date-time', 31, function () {
+test('date-time', 33, function () {
     strictEqual(Date.parse('2001-02-03T04:05'),        +new Date(2001, 1, 3, 4, 5, 0, 0), '2001-02-03T04:05');
     strictEqual(Date.parse('2001-02-03T04:05:06'),     +new Date(2001, 1, 3, 4, 5, 6, 0), '2001-02-03T04:05:06');
     strictEqual(Date.parse('2001-02-03T04:05:06.007'), +new Date(2001, 1, 3, 4, 5, 6, 7), '2001-02-03T04:05:06.007');
@@ -61,6 +61,8 @@ test('date-time', 31, function () {
     strictEqual(Date.parse('2001T04:05:06.007'),             +new Date(2001, 0, 1, 4, 5, 6, 7), '2001T04:05:06.007');
     strictEqual(Date.parse('2001-02T04:05:06.007'),          +new Date(2001, 1, 1, 4, 5, 6, 7), '2001-02T04:05:06.007');
     strictEqual(Date.parse('2001-02-03T04:05:06.007'),       +new Date(2001, 1, 3, 4, 5, 6, 7), '2001-02-03T04:05:06.007');
+    strictEqual(Date.parse('2001-02-03T04:05:06.07'),       +new Date(2001, 1, 3, 4, 5, 6, 70), '2001-02-03T04:05:06.07');
+    strictEqual(Date.parse('2001-02-03T04:05:06.7'),       +new Date(2001, 1, 3, 4, 5, 6, 700), '2001-02-03T04:05:06.7');
     strictEqual(Date.parse('2001-02-03T04:05:06.007-06:30'), Date.UTC(2001, 1, 3, 4, 5, 6, 7) + sixHoursThirty, '2001-02-03T04:05:06.007-06:30');
 
     strictEqual(Date.parse('-010000T04:05'),       +new Date(-10000, 0, 1, 4, 5, 0, 0), '-010000T04:05');


### PR DESCRIPTION
New pull request now targeting to the correct branch.
