### PR TITLE
Allow milliseconds with less digits

### DIFF
--- a/iso8601.js
+++ b/iso8601.js
@@ -4,15 +4,15 @@
  * Released under MIT license.
  */
 (function (Date, undefined) {
-    var origParse = Date.parse, numericKeys = [ 1, 4, 5, 6, 7, 10, 11 ];
+    var origParse = Date.parse, numericKeys = [ 1, 4, 5, 6, 10, 11 ];
     Date.parse = function (date) {
-        var timestamp, struct, minutesOffset = 0;
+        var timestamp, struct, minutesOffset = 0, ms=0;
 
         // ES5 §15.9.4.2 states that the string should attempt to be parsed as a Date Time String Format string
         // before falling back to any implementation-specific date parsing, so that’s what we do, even if native
         // implementations could be faster
         //              1 YYYY                2 MM       3 DD           4 HH    5 mm       6 ss        7 msec        8 Z 9 ±    10 tzHH    11 tzmm
-        if ((struct = /^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?::(\d{2}))?)?)?$/.exec(date))) {
+        if ((struct = /^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?(?:(Z)|([+\-])(\d{2})(?::(\d{2}))?)?)?$/.exec(date))) {
             // avoid NaN timestamps caused by “undefined” values being passed to Date.UTC
             for (var i = 0, k; (k = numericKeys[i]); ++i) {
                 struct[k] = +struct[k] || 0;
@@ -29,8 +29,11 @@
                     minutesOffset = 0 - minutesOffset;
                 }
             }
+            if (struct[7]) {
+                ms = 1000 * ( '0.'+struct[7] );
+            }
 
-            timestamp = Date.UTC(struct[1], struct[2], struct[3], struct[4], struct[5] + minutesOffset, struct[6], struct[7]);
+            timestamp = Date.UTC(struct[1], struct[2], struct[3], struct[4], struct[5] + minutesOffset, struct[6], ms);
         }
         else {
             timestamp = origParse ? origParse(date) : NaN;


### PR DESCRIPTION
Shouldn't you allow this as well?: 2008-12-19T16:39:57.67Z

Also 1 or 2 decimals for the milliseconds?
