### PR TITLE
the colon in timezone is optional per ISO 8601

### DIFF
--- a/iso8601.js
+++ b/iso8601.js
@@ -12,7 +12,7 @@
         // before falling back to any implementation-specific date parsing, so that’s what we do, even if native
         // implementations could be faster
         //              1 YYYY                2 MM       3 DD           4 HH    5 mm       6 ss        7 msec        8 Z 9 ±    10 tzHH    11 tzmm
-        if ((struct = /^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?::(\d{2}))?)?)?$/.exec(date))) {
+        if ((struct = /^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?::?(\d{2}))?)?)?$/.exec(date))) {
             // avoid NaN timestamps caused by “undefined” values being passed to Date.UTC
             for (var i = 0, k; (k = numericKeys[i]); ++i) {
                 struct[k] = +struct[k] || 0;


### PR DESCRIPTION
I can't link to an official ISO-8601 document, but meh, [wikipedia article says so](http://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators), and Chrome 31 and FF 25 are forgiving about it, but if there isn't a colon in the timezine i.e: `+0000` it fails in Safari 7: 

```
var d = "2013-11-11T00:00:00.000+0000";
var d1 = "2013-11-11T00:00:00.000+00:00"
// pre regex change
Date.parse(d); // returns NaN in Safari, but works in Chrome and FF
Date.parse(d1); // works in all 3 browsers and IE8

// post regex change
Date.parse(d); // works in all 4 browsers mentioned above
```

All manual tests on a Mac OS X 10.8

Thanks
