### PR TITLE
fix error in parsing a ISO8601-valid string

### DIFF
--- a/iso8601.js
+++ b/iso8601.js
@@ -12,7 +12,7 @@
         // before falling back to any implementation-specific date parsing, so that’s what we do, even if native
         // implementations could be faster
         //              1 YYYY                2 MM       3 DD           4 HH    5 mm       6 ss        7 msec        8 Z 9 ±    10 tzHH    11 tzmm
-        if ((struct = /^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?::(\d{2}))?)?)?$/.exec(date))) {
+        if ((struct = /^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?:(\d{2}))?)?)?$/.exec(date))) {
             // avoid NaN timestamps caused by “undefined” values being passed to Date.UTC
             for (var i = 0, k; (k = numericKeys[i]); ++i) {
                 struct[k] = +struct[k] || 0;


### PR DESCRIPTION
Problem: "2014-07-02T18:01:00+0200" yields NaN

This is valid string according to [ISO8601](http://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC). It also parses ok on the Chrome and Firefox default Javascript engines, but it fails on Safari OSX7.0.3 and IOS7.
