### PR TITLE
Added support+tests for +HHMM without separator.

### DIFF
--- a/iso8601.js
+++ b/iso8601.js
@@ -11,8 +11,8 @@
         // ES5 §15.9.4.2 states that the string should attempt to be parsed as a Date Time String Format string
         // before falling back to any implementation-specific date parsing, so that’s what we do, even if native
         // implementations could be faster
-        //              1 YYYY                2 MM       3 DD           4 HH    5 mm       6 ss        7 msec        8 Z 9 ±    10 tzHH    11 tzmm
-        if ((struct = /^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?::(\d{2}))?)?)?$/.exec(date))) {
+        //              1 YYYY                2 MM       3 DD           4 HH    5 mm       6 ss        7 msec        8 Z 9 ±    10 tzHH     11 tzmm
+        if ((struct = /^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?::?(\d{2}))?)?)?$/.exec(date))) {
             // avoid NaN timestamps caused by “undefined” values being passed to Date.UTC
             for (var i = 0, k; (k = numericKeys[i]); ++i) {
                 struct[k] = +struct[k] || 0;

--- a/tests/index.html
+++ b/tests/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>ES5 ISO 8601 Test Suite</title>
-    <link rel="stylesheet" href="qunit/qunit/qunit.css" media="screen">
-    <script src="qunit/qunit/qunit.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.14.0.css">
+    <script src="http://code.jquery.com/qunit/qunit-1.14.0.js"></script>
     <script>if (!/[?&]useNativeDateParse(?:\W|$)/.test(location.search)) {
         Date.parse = function () { return NaN; };
         document.write('<script src="../iso8601.js"><\/script>');

--- a/tests/test.js
+++ b/tests/test.js
@@ -32,7 +32,7 @@ test('date-part', 16, function () {
     // TODO: Test for invalid YYYYMM and invalid YYYYY?
 });
 
-test('date-time', 31, function () {
+test('date-time', 35, function () {
     strictEqual(Date.parse('2001-02-03T04:05'),        Date.UTC(2001, 1, 3, 4, 5, 0, 0), '2001-02-03T04:05');
     strictEqual(Date.parse('2001-02-03T04:05:06'),     Date.UTC(2001, 1, 3, 4, 5, 6, 0), '2001-02-03T04:05:06');
     strictEqual(Date.parse('2001-02-03T04:05:06.007'), Date.UTC(2001, 1, 3, 4, 5, 6, 7), '2001-02-03T04:05:06.007');
@@ -44,23 +44,28 @@ test('date-time', 31, function () {
     strictEqual(Date.parse('2001-02-03T04:05-00:00'),        Date.UTC(2001, 1, 3, 4, 5, 0, 0), '2001-02-03T04:05-00:00');
     strictEqual(Date.parse('2001-02-03T04:05:06-00:00'),     Date.UTC(2001, 1, 3, 4, 5, 6, 0), '2001-02-03T04:05:06-00:00');
     strictEqual(Date.parse('2001-02-03T04:05:06.007-00:00'), Date.UTC(2001, 1, 3, 4, 5, 6, 7), '2001-02-03T04:05:06.007-00:00');
+    strictEqual(Date.parse('2001-02-03T04:05:06.007-0000'), Date.UTC(2001, 1, 3, 4, 5, 6, 7), '2001-02-03T04:05:06.007-0000');
 
     strictEqual(Date.parse('2001-02-03T04:05+00:00'),        Date.UTC(2001, 1, 3, 4, 5, 0, 0), '2001-02-03T04:05+00:00');
     strictEqual(Date.parse('2001-02-03T04:05:06+00:00'),     Date.UTC(2001, 1, 3, 4, 5, 6, 0), '2001-02-03T04:05:06+00:00');
     strictEqual(Date.parse('2001-02-03T04:05:06.007+00:00'), Date.UTC(2001, 1, 3, 4, 5, 6, 7), '2001-02-03T04:05:06.007+00:00');
+    strictEqual(Date.parse('2001-02-03T04:05:06.007+0000'), Date.UTC(2001, 1, 3, 4, 5, 6, 7), '2001-02-03T04:05:06.007+0000');
 
     strictEqual(Date.parse('2001-02-03T04:05-06:30'),        Date.UTC(2001, 1, 3, 4, 5, 0, 0) + sixHoursThirty, '2001-02-03T04:05-06:30');
     strictEqual(Date.parse('2001-02-03T04:05:06-06:30'),     Date.UTC(2001, 1, 3, 4, 5, 6, 0) + sixHoursThirty, '2001-02-03T04:05:06-06:30');
     strictEqual(Date.parse('2001-02-03T04:05:06.007-06:30'), Date.UTC(2001, 1, 3, 4, 5, 6, 7) + sixHoursThirty, '2001-02-03T04:05:06.007-06:30');
+    strictEqual(Date.parse('2001-02-03T04:05:06.007-0630'), Date.UTC(2001, 1, 3, 4, 5, 6, 7) + sixHoursThirty, '2001-02-03T04:05:06.007-0630');
 
     strictEqual(Date.parse('2001-02-03T04:05+06:30'),        Date.UTC(2001, 1, 3, 4, 5, 0, 0) - sixHoursThirty, '2001-02-03T04:05+06:30');
     strictEqual(Date.parse('2001-02-03T04:05:06+06:30'),     Date.UTC(2001, 1, 3, 4, 5, 6, 0) - sixHoursThirty, '2001-02-03T04:05:06+06:30');
     strictEqual(Date.parse('2001-02-03T04:05:06.007+06:30'), Date.UTC(2001, 1, 3, 4, 5, 6, 7) - sixHoursThirty, '2001-02-03T04:05:06.007+06:30');
+    strictEqual(Date.parse('2001-02-03T04:05:06.007+0630'), Date.UTC(2001, 1, 3, 4, 5, 6, 7) - sixHoursThirty, '2001-02-03T04:05:06.007+0630');
 
     strictEqual(Date.parse('2001T04:05:06.007'),             Date.UTC(2001, 0, 1, 4, 5, 6, 7), '2001T04:05:06.007');
     strictEqual(Date.parse('2001-02T04:05:06.007'),          Date.UTC(2001, 1, 1, 4, 5, 6, 7), '2001-02T04:05:06.007');
     strictEqual(Date.parse('2001-02-03T04:05:06.007'),       Date.UTC(2001, 1, 3, 4, 5, 6, 7), '2001-02-03T04:05:06.007');
     strictEqual(Date.parse('2001-02-03T04:05:06.007-06:30'), Date.UTC(2001, 1, 3, 4, 5, 6, 7) + sixHoursThirty, '2001-02-03T04:05:06.007-06:30');
+    strictEqual(Date.parse('2001-02-03T04:05:06.007-0630'), Date.UTC(2001, 1, 3, 4, 5, 6, 7) + sixHoursThirty, '2001-02-03T04:05:06.007-0630');
 
     strictEqual(Date.parse('-010000T04:05'),       Date.UTC(-10000, 0, 1, 4, 5, 0, 0), '-010000T04:05');
     strictEqual(Date.parse('-010000-02T04:05'),    Date.UTC(-10000, 1, 1, 4, 5, 0, 0), '-010000-02T04:05');
@@ -69,7 +74,6 @@ test('date-time', 31, function () {
     ok(isNaN(Date.parse('1970-01-01 00:00:00')), 'invalid date-time (missing T)');
     ok(isNaN(Date.parse('1970-01-01T00:00:00.000000')), 'invalid date-time (too many characters in millisecond part)');
     ok(isNaN(Date.parse('1970-01-01T00:00:00,000')), 'invalid date-time (comma instead of dot)');
-    ok(isNaN(Date.parse('1970-01-01T00:00:00+0630')), 'invalid date-time (missing colon in timezone part)');
     ok(isNaN(Date.parse('1970-01-01T0000')), 'invalid date-time (missing colon in time part)');
     ok(isNaN(Date.parse('1970-01-01T00:00.000')), 'invalid date-time (msec with missing seconds)');
 


### PR DESCRIPTION
According to Wikipedia at least, the +HHMM syntax is valid without the colon. I've made adjustments to the regex and some tests. I've commented out the test that explicitly checked this doesn't work because I think it's wrong. :)

Edit: Also added links to the qunit CDN so you don't have to download it yourself.
